### PR TITLE
Update Zero to Hero - Kubernetes and Kasten K10.md

### DIFF
--- a/Zero to Hero - Kubernetes and Kasten K10.md
+++ b/Zero to Hero - Kubernetes and Kasten K10.md
@@ -92,7 +92,7 @@ To expose and access this run the following port-forward in a new terminal
 
 `kubectl port-forward svc/pacman 9191:80 -n pacman`
 
-Open a browser and navigate to [http://localhost:9090/](http://localhost:9090/)
+Open a browser and navigate to [http://localhost:9191/](http://localhost:9191/)
 
 ## Install Minio
 ```


### PR DESCRIPTION
section: "Deploy Data Services (Pac-Man)": change port number in link to exposed port 9191 instead of 9090